### PR TITLE
Remove redundant title from feature plan issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/planned_feature_form.yml
+++ b/.github/ISSUE_TEMPLATE/planned_feature_form.yml
@@ -1,15 +1,6 @@
 name: Feature Plan
 description: Create a feature plan as part of a milestone or project.
 body:
-  - type: input
-    id: feature-name
-    attributes:
-      label: "Feature Name:"
-      description: |
-        The name or short summary of the feature you want implemented.
-      placeholder: "Refactor Everything"
-    validations:
-      required: true
   - type: textarea
     id: feature-description
     attributes:


### PR DESCRIPTION

## About The Pull Request
GitHub already has a title for every issue, so the feature name field wasn't necessary
## Why It's Good For The Game
Neatness
